### PR TITLE
Fixed stylesheet link in orange/base.html

### DIFF
--- a/orange/templates/orange/base.html
+++ b/orange/templates/orange/base.html
@@ -5,7 +5,7 @@
     <head>
         <title>{% block title %}{% endblock title %}</title>
 
-        <link rel="stylesheet" type="text/css" href="/static/@fortawesome/fontawesome-free/css/all.css" />
+        <link rel="stylesheet" type="text/css" href="{% static "@fortawesome/fontawesome-free/css/all.css" %}" />
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css"
               rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl"
               crossorigin="anonymous">


### PR DESCRIPTION
Necessary now that static assets are being served from a different subdomain in production.