### PR TITLE
More year dropdowns

### DIFF
--- a/kilo/models.py
+++ b/kilo/models.py
@@ -36,6 +36,14 @@ class Day(models.Model):
         today = datetime.now().date()
         return Day.objects.filter(day__gte=today - timedelta(days=days))
 
+    @classmethod
+    def get_year(cls, year=None):
+        try:
+            year = int(year)
+        except (TypeError, ValueError):
+            year = datetime.now().year
+        return Day.objects.filter(day__gte=f"{year}-01-01", day__lte=f"{year}-12-31")
+
     @property
     def primary_activity(self):
         if self.workout_set.count() == 0:

--- a/kilo/static/kilo/js/utils.js
+++ b/kilo/static/kilo/js/utils.js
@@ -69,8 +69,6 @@ function navigateVisual(page, url, year) {
     if (page === "erging" || page === "running") {
         let url = document.getElementById('pace-url').innerHTML;
         loadPaceChart(url + '?activity=' + page + '&year=' + year);
-    } else if (page === "history") {
-        c3.generate(getFrequencyGraphOptions());
     } else {
         clearChart();
     }

--- a/kilo/static/kilo/js/utils.js
+++ b/kilo/static/kilo/js/utils.js
@@ -67,6 +67,7 @@ function initDropdowns(event) {
 
 function navigateVisual(page, url, year) {
     if (page === "erging" || page === "running") {
+        let url = document.getElementById('pace-url').innerHTML;
         loadPaceChart(url + '?activity=' + page + '&year=' + year);
     } else if (page === "history") {
         c3.generate(getFrequencyGraphOptions());

--- a/kilo/static/kilo/js/utils.js
+++ b/kilo/static/kilo/js/utils.js
@@ -2,7 +2,6 @@ function getFrequencyGraphOptions() {
     return getGraphOptions();
 }
 
-
 function getGraphOptions() {
     return JSON.parse(document.getElementById('graph-options').innerHTML);
 }
@@ -64,4 +63,15 @@ function initDropdowns(event) {
     dropdowns.forEach(d => new Choices(d, {
         itemSelectText: "",
     }));
+}
+
+function navigateVisual(page, url) {
+    if (url && (page === "erging" || page === "running")) {
+        loadPaceChart(url + '?activity=' + page);
+    } else if (page === "history") {
+        c3.generate(getFrequencyGraphOptions());
+    } else {
+        clearChart();
+    }
+    hideRecent();
 }

--- a/kilo/static/kilo/js/utils.js
+++ b/kilo/static/kilo/js/utils.js
@@ -65,9 +65,9 @@ function initDropdowns(event) {
     }));
 }
 
-function navigateVisual(page, url) {
-    if (url && (page === "erging" || page === "running")) {
-        loadPaceChart(url + '?activity=' + page);
+function navigateVisual(page, url, year) {
+    if (page === "erging" || page === "running") {
+        loadPaceChart(url + '?activity=' + page + '&year=' + year);
     } else if (page === "history") {
         c3.generate(getFrequencyGraphOptions());
     } else {

--- a/kilo/templates/kilo/base.html
+++ b/kilo/templates/kilo/base.html
@@ -36,12 +36,15 @@
       <div class="collapse navbar-collapse" id="kilo-nav">
         <ul class="navbar-nav flex-grow-1">
           <li class="nav-item">
-            <a class="nav-link" href="#"
-               hx-get="{% url "stats" %}"
-               hx-target="#panel"
-               hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('stats')"
-            >PRs</a>
+            <div class="btn-group">
+              <a class="nav-link" href="#"
+                 hx-get="{% url "stats" %}"
+                 hx-target="#panel"
+                 hx-indicator="#loading"
+                   hx-on:htmx:after-request="navigateVisual('stats')"
+              >PRs</a>
+              {% include "kilo/partials/years_dropdown.html" with url_name="stats" %}
+            </div>
           </li>
           <li class="nav-item">
             <div class="btn-group">

--- a/kilo/templates/kilo/base.html
+++ b/kilo/templates/kilo/base.html
@@ -66,20 +66,26 @@
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#"
-               hx-get="{% url "lifting" %}"
-               hx-target="#panel"
-               hx-indicator="#loading"
-               hx-on:htmx:after-request="clearChart(); hideRecent()"
-            >Lifting</a>
+            <div class="btn-group">
+              <a class="nav-link" href="#"
+                 hx-get="{% url "lifting" %}"
+                 hx-target="#panel"
+                 hx-indicator="#loading"
+                 hx-on:htmx:after-request="clearChart(); hideRecent()"
+              >Lifting</a>
+              {% include "kilo/partials/years_dropdown.html" with url_name="lifting" %}
+            </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#"
-               hx-get="{% url "long_runs" %}"
-               hx-target="#panel"
-               hx-indicator="#loading"
-               hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=running'); hideRecent()"
-            >Long Runs</a>
+            <div class="btn-group">
+              <a class="nav-link" href="#"
+                 hx-get="{% url "long_runs" %}"
+                 hx-target="#panel"
+                 hx-indicator="#loading"
+                 hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=running'); hideRecent()"
+              >Long Runs</a>
+              {% include "kilo/partials/years_dropdown.html" with url_name="long_runs" %}
+            </div>
           </li>
         </ul>
       </div>

--- a/kilo/templates/kilo/base.html
+++ b/kilo/templates/kilo/base.html
@@ -41,7 +41,7 @@
                  hx-get="{% url "stats" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('stats', '{% url "pace" %}')"
+                 hx-on:htmx:after-request="navigateVisual('stats')"
               >PRs</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="stats" %}
             </div>
@@ -52,7 +52,7 @@
                  hx-get="{% url "history" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('history', '{% url "pace" %}')"
+                 hx-on:htmx:after-request="navigateVisual('history')"
               >History</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="history" %}
             </div>
@@ -63,7 +63,7 @@
                  hx-get="{% url "erging" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('erging', '{% url "pace" %}')"
+                 hx-on:htmx:after-request="navigateVisual('erging')"
               >Erging</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="erging" %}
             </div>
@@ -74,7 +74,7 @@
                  hx-get="{% url "lifting" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('lifting', '{% url "pace" %}')"
+                 hx-on:htmx:after-request="navigateVisual('lifting')"
               >Lifting</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="lifting" %}
             </div>
@@ -85,7 +85,7 @@
                  hx-get="{% url "long_runs" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('running', '{% url "pace" %}')"
+                 hx-on:htmx:after-request="navigateVisual('running')"
               >Long Runs</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="long_runs" %}
             </div>
@@ -118,5 +118,6 @@
          hx-on:htmx:after-swap="initDropdowns(event)">
     </div>
     <div id="graph-options" style="display: none;"></div>
+    <div id="pace-url" style="display: none;">{% url "pace" %}</div>
   </div>
 {% endblock body %}

--- a/kilo/templates/kilo/base.html
+++ b/kilo/templates/kilo/base.html
@@ -40,7 +40,7 @@
                hx-get="{% url "stats" %}"
                hx-target="#panel"
                hx-indicator="#loading"
-               hx-on:htmx:after-request="clearChart(); hideRecent()"
+                 hx-on:htmx:after-request="navigateVisual('stats')"
             >PRs</a>
           </li>
           <li class="nav-item">
@@ -49,7 +49,7 @@
                  hx-get="{% url "history" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
+                 hx-on:htmx:after-request="navigateVisual('history')"
               >History</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="history" %}
             </div>
@@ -60,7 +60,7 @@
                  hx-get="{% url "erging" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=erging'); hideRecent()"
+                 hx-on:htmx:after-request="navigateVisual('erging', '{% url "pace" %}')"
               >Erging</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="erging" %}
             </div>
@@ -71,7 +71,7 @@
                  hx-get="{% url "lifting" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="clearChart(); hideRecent()"
+                 hx-on:htmx:after-request="navigateVisual('lifting')"
               >Lifting</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="lifting" %}
             </div>
@@ -82,7 +82,7 @@
                  hx-get="{% url "long_runs" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=running'); hideRecent()"
+                 hx-on:htmx:after-request="navigateVisual('running', '{% url "pace" %}')"
               >Long Runs</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="long_runs" %}
             </div>

--- a/kilo/templates/kilo/base.html
+++ b/kilo/templates/kilo/base.html
@@ -69,12 +69,29 @@
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#"
-               hx-get="{% url "erging" %}"
-               hx-target="#panel"
-               hx-indicator="#loading"
-               hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=erging'); hideRecent()"
-            >Erging</a>
+            <div class="btn-group">
+              <a class="nav-link" href="#"
+                 hx-get="{% url "erging" %}"
+                 hx-target="#panel"
+                 hx-indicator="#loading"
+                 hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=erging'); hideRecent()"
+              >Erging</a>
+              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="visually-hidden">Toggle Erging Dropdown</span>
+              </button>
+              <ul class="dropdown-menu">
+                {% for year in years %}
+                  <li>
+                    <a class="dropdown-item" href="#"
+                       hx-get="{% url "erging" %}?year={{ year }}"
+                       hx-target="#panel"
+                       hx-indicator="#loading"
+                       hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
+                    >{{ year }}</a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#"

--- a/kilo/templates/kilo/base.html
+++ b/kilo/templates/kilo/base.html
@@ -51,21 +51,7 @@
                  hx-indicator="#loading"
                  hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
               >History</a>
-              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                <span class="visually-hidden">Toggle History Dropdown</span>
-              </button>
-              <ul class="dropdown-menu">
-                {% for year in years %}
-                  <li>
-                    <a class="dropdown-item" href="#"
-                       hx-get="{% url "history" %}?year={{ year }}"
-                       hx-target="#panel"
-                       hx-indicator="#loading"
-                       hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
-                    >{{ year }}</a>
-                  </li>
-                {% endfor %}
-              </ul>
+              {% include "kilo/partials/years_dropdown.html" with url_name="history" %}
             </div>
           </li>
           <li class="nav-item">
@@ -76,21 +62,7 @@
                  hx-indicator="#loading"
                  hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=erging'); hideRecent()"
               >Erging</a>
-              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                <span class="visually-hidden">Toggle Erging Dropdown</span>
-              </button>
-              <ul class="dropdown-menu">
-                {% for year in years %}
-                  <li>
-                    <a class="dropdown-item" href="#"
-                       hx-get="{% url "erging" %}?year={{ year }}"
-                       hx-target="#panel"
-                       hx-indicator="#loading"
-                       hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
-                    >{{ year }}</a>
-                  </li>
-                {% endfor %}
-              </ul>
+              {% include "kilo/partials/years_dropdown.html" with url_name="erging" %}
             </div>
           </li>
           <li class="nav-item">

--- a/kilo/templates/kilo/base.html
+++ b/kilo/templates/kilo/base.html
@@ -41,7 +41,7 @@
                  hx-get="{% url "stats" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                   hx-on:htmx:after-request="navigateVisual('stats')"
+                 hx-on:htmx:after-request="navigateVisual('stats', '{% url "pace" %}')"
               >PRs</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="stats" %}
             </div>
@@ -52,7 +52,7 @@
                  hx-get="{% url "history" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('history')"
+                 hx-on:htmx:after-request="navigateVisual('history', '{% url "pace" %}')"
               >History</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="history" %}
             </div>
@@ -74,7 +74,7 @@
                  hx-get="{% url "lifting" %}"
                  hx-target="#panel"
                  hx-indicator="#loading"
-                 hx-on:htmx:after-request="navigateVisual('lifting')"
+                 hx-on:htmx:after-request="navigateVisual('lifting', '{% url "pace" %}')"
               >Lifting</a>
               {% include "kilo/partials/years_dropdown.html" with url_name="lifting" %}
             </div>

--- a/kilo/templates/kilo/partials/years_dropdown.html
+++ b/kilo/templates/kilo/partials/years_dropdown.html
@@ -8,7 +8,7 @@
          hx-get="{% url url_name %}?year={{ year }}"
          hx-target="#panel"
          hx-indicator="#loading"
-         hx-on:htmx:after-request="navigateVisual('{{ url_name }}', '{% url "pace" %}')"
+         hx-on:htmx:after-request="navigateVisual('{{ url_name }}', '{% url "pace" %}', '{{ year }}')"
       >{{ year }}</a>
     </li>
   {% endfor %}

--- a/kilo/templates/kilo/partials/years_dropdown.html
+++ b/kilo/templates/kilo/partials/years_dropdown.html
@@ -8,15 +8,7 @@
          hx-get="{% url url_name %}?year={{ year }}"
          hx-target="#panel"
          hx-indicator="#loading"
-         {% if url_name == "erging" %}
-           hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=erging'); hideRecent()"
-         {% elif url_name == "long_runs" %}
-           hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=running'); hideRecent()"
-         {% elif url_name == "history" %}
-           hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
-         {% else %}
-           hx-on:htmx:after-request="clearChart(); hideRecent()"
-         {% endif %}
+         hx-on:htmx:after-request="navigateVisual('{{ url_name }}', '{% url "pace" %}')"
       >{{ year }}</a>
     </li>
   {% endfor %}

--- a/kilo/templates/kilo/partials/years_dropdown.html
+++ b/kilo/templates/kilo/partials/years_dropdown.html
@@ -10,8 +10,12 @@
          hx-indicator="#loading"
          {% if url_name == "erging" %}
            hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=erging'); hideRecent()"
-         {% else %}
+         {% elif url_name == "long_runs" %}
+           hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=running'); hideRecent()"
+         {% elif url_name == "history" %}
            hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
+         {% else %}
+           hx-on:htmx:after-request="clearChart(); hideRecent()"
          {% endif %}
       >{{ year }}</a>
     </li>

--- a/kilo/templates/kilo/partials/years_dropdown.html
+++ b/kilo/templates/kilo/partials/years_dropdown.html
@@ -8,7 +8,7 @@
          hx-get="{% url url_name %}?year={{ year }}"
          hx-target="#panel"
          hx-indicator="#loading"
-         hx-on:htmx:after-request="navigateVisual('{{ url_name }}', '{% url "pace" %}', '{{ year }}')"
+         hx-on:htmx:after-request="navigateVisual('{{ url_name }}', '{{ year }}')"
       >{{ year }}</a>
     </li>
   {% endfor %}

--- a/kilo/templates/kilo/partials/years_dropdown.html
+++ b/kilo/templates/kilo/partials/years_dropdown.html
@@ -1,0 +1,19 @@
+<button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+  <span class="visually-hidden">Toggle Dropdown</span>
+</button>
+<ul class="dropdown-menu">
+  {% for year in years %}
+    <li>
+      <a class="dropdown-item" href="#"
+         hx-get="{% url url_name %}?year={{ year }}"
+         hx-target="#panel"
+         hx-indicator="#loading"
+         {% if url_name == "erging" %}
+           hx-on:htmx:after-request="loadPaceChart('{% url "pace" %}?activity=erging'); hideRecent()"
+         {% else %}
+           hx-on:htmx:after-request="c3.generate(getFrequencyGraphOptions()); hideRecent()"
+         {% endif %}
+      >{{ year }}</a>
+    </li>
+  {% endfor %}
+</ul>

--- a/kilo/views.py
+++ b/kilo/views.py
@@ -224,37 +224,44 @@ def _format_day(day):
 @require_GET
 @login_required
 def stats(request):
-    last_year_days = Day.get_recent_days(365)
-    last_month_days = Day.get_recent_days(30)
+    year = request.GET.get('year')
+    days = Day.get_year(year)
+
+    try:
+        year = int(year)
+    except (TypeError, ValueError):
+        year = None
 
     erging_stats = []
-    erging_stats.append({
-        "name": "Past Month",
-        "primary": sum_erging(last_month_days),
-        "secondary": "total m erged"}
-    )
-    workout = best_erg(last_month_days, km=2)
-    if workout:
+    if not year:
+        last_month_days = Day.get_recent_days(30)
         erging_stats.append({
-            "name": "Past Month's Best 2k",
-            "primary": workout.primary_stat(),
-            "secondary": workout.secondary_stat(),
-        })
-    workout = best_erg(last_month_days, km=6)
-    if workout:
-        erging_stats.append({
-            "name": "Past Month's Best 6k",
-            "primary": workout.primary_stat(),
-            "secondary": workout.secondary_stat(),
-        })
-    workout = best_erg(last_year_days, km=2)
+            "name": "Past Month",
+            "primary": sum_erging(last_month_days),
+            "secondary": "total m erged"}
+        )
+        workout = best_erg(last_month_days, km=2)
+        if workout:
+            erging_stats.append({
+                "name": "Past Month's Best 2k",
+                "primary": workout.primary_stat(),
+                "secondary": workout.secondary_stat(),
+            })
+        workout = best_erg(last_month_days, km=6)
+        if workout:
+            erging_stats.append({
+                "name": "Past Month's Best 6k",
+                "primary": workout.primary_stat(),
+                "secondary": workout.secondary_stat(),
+            })
+    workout = best_erg(days, km=2)
     if workout:
         erging_stats.append({
             "name": "Best 2k",
             "primary": workout.primary_stat(),
             "secondary": workout.secondary_stat(),
         })
-    workout = best_erg(last_year_days, km=6)
+    workout = best_erg(days, km=6)
     if workout:
         erging_stats.append({
             "name": "Best 6k",
@@ -263,34 +270,36 @@ def stats(request):
         })
 
     running_stats = []
-    running_stats.append({
-        "name": "Past Month",
-        "primary": sum_running(last_month_days),
-        "secondary": "total miles run",
-    })
     boundary = 7
-    workout = best_run(last_month_days, upper_mi=boundary)
-    if workout:
+    if not year:
+        last_month_days = Day.get_recent_days(30)
         running_stats.append({
-            "name": "Past Month's Best Short Run",
-            "primary": workout.primary_stat(),
-            "secondary": workout.secondary_stat(),
+            "name": "Past Month",
+            "primary": sum_running(last_month_days),
+            "secondary": "total miles run",
         })
-    workout = best_run(last_month_days, lower_mi=boundary)
-    if workout:
-        running_stats.append({
-            "name": "Past Month's Best Long Run",
-            "primary": workout.primary_stat(),
-            "secondary": workout.secondary_stat(),
-        })
-    workout = best_run(last_year_days, upper_mi=boundary)
+        workout = best_run(last_month_days, upper_mi=boundary)
+        if workout:
+            running_stats.append({
+                "name": "Past Month's Best Short Run",
+                "primary": workout.primary_stat(),
+                "secondary": workout.secondary_stat(),
+            })
+        workout = best_run(last_month_days, lower_mi=boundary)
+        if workout:
+            running_stats.append({
+                "name": "Past Month's Best Long Run",
+                "primary": workout.primary_stat(),
+                "secondary": workout.secondary_stat(),
+            })
+    workout = best_run(days, upper_mi=boundary)
     if workout:
         running_stats.append({
             "name": "Best Short Run",
             "primary": workout.primary_stat(),
             "secondary": workout.secondary_stat(),
         })
-    workout = best_run(last_year_days, lower_mi=boundary)
+    workout = best_run(days, lower_mi=boundary)
     if workout:
         running_stats.append({
             "name": "Best Long Run",
@@ -298,9 +307,14 @@ def stats(request):
             "secondary": workout.secondary_stat(),
         })
 
-    last_year = datetime.now().date() - timedelta(days=365)
-    lifting_workouts = Workout.objects.filter(weight__isnull=False, day__day__gte=last_year)
+    lifting_workouts = Workout.objects.filter(weight__isnull=False)
+    if year:
+        lifting_workouts = lifting_workouts.filter(day__day__gte=f"{year}-01-01", day__day__lte=f"{year}-12-31")
+    else:
+        last_year = datetime.now().date() - timedelta(days=365)
+        lifting_workouts = lifting_workouts.filter(day__day__gte=last_year)
     lifting_stats = []
+
     for activity in lifting_workouts.order_by('activity').values_list('activity', flat=True).distinct():
         workout = lifting_workouts.filter(activity=activity).order_by('-weight').first()
         lifting_stats.append({
@@ -311,13 +325,13 @@ def stats(request):
 
     return render(request, "kilo/partials/stats.html", {
         "stats": [{
-            "title": "Erging",
+            "title": f"Erging {year or ''}",
             "stats": erging_stats,
         }, {
-            "title": "Running",
+            "title": f"Running {year or ''}",
             "stats": running_stats,
         }, {
-            "title": "Lifting",
+            "title": f"Lifting {year or ''}",
             "stats": lifting_stats,
         }],
     })

--- a/kilo/views.py
+++ b/kilo/views.py
@@ -173,8 +173,9 @@ def history(request):
 @require_GET
 @login_required
 def erging(request):
-    today = datetime.now().date()
-    days = Day.objects.filter(workout__activity="erging", day__gte=today - timedelta(days=180))
+    year =  request.GET.get('year')
+    days = Day.get_year(year)
+    days = days.filter(workout__activity="erging")
     return _days(request, days)
 
 

--- a/kilo/views.py
+++ b/kilo/views.py
@@ -383,7 +383,9 @@ def pace(request):
     activity_filter = request.GET.get('activity')
     if activity_filter not in ('running', 'erging'):
         return HttpResponse(f"Invalid activity '{activity_filter}', expected 'running' or 'erging'", status=400)
-    days = Day.get_recent_days(365)
+
+    year =  request.GET.get('year')
+    days = Day.get_year(year)
 
     def interval_filter(wset, activity, distance_test):
         if any([w.activity != activity for w in wset.all()]):

--- a/kilo/views.py
+++ b/kilo/views.py
@@ -166,11 +166,7 @@ def recent(request):
 @login_required
 def history(request):
     year =  request.GET.get('year')
-    if year:
-        year = int(year)
-    else:
-        year = datetime.now().year
-    days = Day.objects.filter(day__gte=f"{year}-01-01", day__lte=f"{year}-12-31")
+    days = Day.get_year(year)
     return _days(request, days)
 
 


### PR DESCRIPTION
<img width="528" height="43" alt="Screenshot 2026-08-02 at 12 09 10 PM" src="https://github.com/user-attachments/assets/1b5833b8-5680-43c9-a0ec-336b456e9862" />

It might be nicer to do a single drop down for the "Kilo" item, and then make all other nav items use that year. And also make the frequency graph respect the "current" year.